### PR TITLE
Use lambda-git

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "aws-sdk": "^2.72.0",
     "debug": "^2.6.3",
     "github": "^9.2.0",
+    "lambda-git": "^0.1.2",
     "nconf": "^0.8.4",
     "q": "^1.5.0",
     "serverless-prune-plugin": "^1.0.4",

--- a/serverless.yml
+++ b/serverless.yml
@@ -80,8 +80,6 @@ package:
   # only the following paths will be included in the resulting artifact which will be uploaded. Without specific include everything in the current folder will be included
   include:
     - src
-    - functions
-    - opt
   # The following paths will be excluded from the resulting artifact. If both include and exclude are defined we first apply the include, then the exclude so files are guaranteed to be excluded
   exclude:
     - tmp

--- a/src/common/git.js
+++ b/src/common/git.js
@@ -3,15 +3,6 @@ var q = require("q");  // npm install q
 var fs = require('fs')
 var path = require('path');
 
-var targetDirectory = path.resolve(__dirname, "../../opt/")
-var GIT_TEMPLATE_DIR = path.resolve(targetDirectory, 'usr/share/git-core/templates');
-var GIT_EXEC_PATH = path.resolve(targetDirectory, 'usr/libexec/git-core');
-
-process.env.PATH = path.resolve(targetDirectory, 'usr/bin') + ":" + process.env.PATH  ;
-process.env.GIT_TEMPLATE_DIR = GIT_TEMPLATE_DIR;
-process.env.GIT_EXEC_PATH = GIT_EXEC_PATH;
-
-
 module.exports.cloneRepo = function(gitRemote, destination){
     return execGitCmd(`git clone --depth 1 ${gitRemote} ${destination}`)
 }
@@ -58,9 +49,21 @@ module.exports.pushRepo = function(repoPath, branchName){
     return execGitCmd(`git push origin ${branchName}`, repoPath)
 }
 
-
+var GitPath = '/tmp/git.gitmask';
+var gitExpand = false;
 
 function execGitCmd(cmd, cwd, env){
+    if (gitExpand && fs.existsSync(GitPath)) {
+        // Use the existing one as it takes much time to expand git everytime.
+        return execGitCmdImpl(cmd, cwd, env);
+    }
+    return require('lambda-git')({targetDirectory: GitPath}).then(function(){
+        gitExpand = true;
+        return execGitCmdImpl(cmd, cwd, env);
+    });
+}
+
+function execGitCmdImpl(cmd, cwd, env){
     var opts = {}
     if(cwd){
         opts.cwd = cwd;
@@ -78,5 +81,5 @@ function execGitCmd(cmd, cwd, env){
         if (err) return deferred.reject(err);
         return deferred.resolve(stdout)
     });
-    return deferred.promise
+    return deferred.promise;
 }


### PR DESCRIPTION
Though it looks expected to have opt/git-2.4.3.tar expanded when deploying, it results following error:
```
Serverless: Operation failed!

  Serverless Error ---------------------------------------

  An error occurred: ProcessbundleLambdaFunction - Unzipped size must be smaller than 262144000 bytes (Service: AWSLambda; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: xxxxxxxxxxxxxxxxxxxxxxxxxxx).
```

This request uses [lambda-git](https://github.com/pimterry/lambda-git) instead.
