### PR TITLE
Add instructions to deploy for testing purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,55 @@
  * [Anonymous Github](https://github.com/tdurieux/anonymous_github) is a proxy server to support anonymous browsing of Github repositories for open-science code and data.
 
  * [blind-reviews](https://github.com/zombie/blind-reviews/) hides the name of a pull request submitter in the browser, to help maintainers break bias habits and take a first look at the code on its own merits. (It does not change the identifying information.)
+
+# How to run gitmask in your serverless environment
+
+For testing purpose, so on.
+
+## Prerequisites
+
+* AWS account where your gitmask run.
+* Install nodejs, serverless-framework and aws-cli.
+    * https://nodejs.org/
+    * https://serverless.com/
+    * https://aws.amazon.com/cli/
+
+## Steps to run gitmask
+
+1. Create and setup the AWS user for the deployment.
+
+     * Set up the credentials with `aws configure`
+     * You may use the AWS account root user.
+     * You can create a new IAM user with restrict permissions.
+        * https://serverless.com/blog/abcs-of-iam-permissions/ may help you.
+
+2. Issue your github access token
+
+    * Go to github Settings > Developer settings > Personal access tokens
+    * Run generate new token
+        * scopes
+            * public_repo
+
+3. Configure following environment variables:
+
+    |Variable                 |Value  |
+    |:------------------------|:-------------|
+    |GITHUB_API_TOKEN         |github personal access token|
+    |GITHUB_USER              |github username of the personal access token|
+    |GITMASK_SERVICE          |Your own service name for gitmask, e.g. myown-gitmask-api.|
+    |GITMASK_SERVICE_NORMALIZE|Normalized value for GITMASK_SERVICE,removing special characters and captalize the first letter. e.g. Myowngitmaskapi |
+    |CIRCLE_SHA1              |Set the value retrieved by `git rev-parse --short HEAD`|
+
+4. Run deployment
+
+    ```
+    sls deploy
+    ```
+
+    * The URLs for endpoints are shown.
+        * You can redisplay that with `sls info`
+
+### To remove the deployment
+
+You can uninstall the deployment with `sls remove`.
+You have to have the S3 bucket (GITMASK_SERVICE)-(stage)-upload empty in advance.

--- a/cloudformation-resources.yaml
+++ b/cloudformation-resources.yaml
@@ -5,14 +5,15 @@
 # https://github.com/serverless/serverless/issues/2967
 # https://serverless.com/framework/docs/providers/aws/guide/resources/#aws-cloudformation-resource-reference
 
-#S3BucketGitmaskapi:
+# This will be automatically generated from serverless.yaml.
+#S3Bucket${env:GITMASK_SERVICE_NORMALIZE, 'Gitmaskapi'}:
 #  Type: AWS::S3::Bucket
 #  Properties:
 #    BucketName: "${self:service}-${opt:stage, self:provider.stage}-upload"
 
 
 GitmaskUploadBucketPolicy:
-  DependsOn: "S3BucketGitmaskapi${opt:stage, self:provider.stage}upload"
+  DependsOn: "S3Bucket${env:GITMASK_SERVICE_NORMALIZE, 'Gitmaskapi'}${opt:stage, self:provider.stage}upload"
   Type: AWS::S3::BucketPolicy
   Properties:
     PolicyDocument:
@@ -27,7 +28,7 @@ GitmaskUploadBucketPolicy:
           Fn::Join:
           - ''
           - - 'arn:aws:s3:::'
-            - Ref: "S3BucketGitmaskapi${opt:stage, self:provider.stage}upload"
+            - Ref: "S3Bucket${env:GITMASK_SERVICE_NORMALIZE, 'Gitmaskapi'}${opt:stage, self:provider.stage}upload"
             - "/*"
     Bucket:
-      Ref: "S3BucketGitmaskapi${opt:stage, self:provider.stage}upload"
+      Ref: "S3Bucket${env:GITMASK_SERVICE_NORMALIZE, 'Gitmaskapi'}${opt:stage, self:provider.stage}upload"

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@
 #
 # Happy Coding!
 
-service: gitmask-api # NOTE: update this with your service name
+service: ${env:GITMASK_SERVICE, 'gitmask-api'} # NOTE: update this with your service name
 
 provider:
   cfLogs: true
@@ -22,10 +22,12 @@ provider:
   runtime: nodejs4.3
   memorySize: 128
   environment:
+    GITMASK_SERVICE: ${self:service}
     DOMAIN: git.gitmask.com
     DEPLOY_SHA: ${env:CIRCLE_SHA1}
     STAGE: ${opt:stage, self:provider.stage}
     NODE_ENV: production
+    GITHUB_USER: ${env:GITHUB_USER, 'gitmask-anonymous'}
     GITHUB_API_TOKEN: ${env:GITHUB_API_TOKEN}
     DEBUG: gitmask:*
 

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -6,6 +6,6 @@ module.exports = {
     buckets: {
         // upload bucket contains files that are temporarily located in S3, and will need to be processed, ie:
         // - files manually uploaded via WebUI
-        upload: 'gitmask-api-' + nconf.get('STAGE') + '-upload',
+        upload: nconf.get('GITMASK_SERVICE') + '-' + nconf.get('STAGE') + '-upload',
     }
 }

--- a/src/process.js
+++ b/src/process.js
@@ -52,7 +52,7 @@ module.exports.handler = (event, context, callback) => {
 
 
 
-    var gitmask_org = 'gitmask-anonymous'
+    var gitmask_org = nconf.get('GITHUB_USER')
 
     debug("Begin processing bundle: ", upload_key_parts);
 


### PR DESCRIPTION
Hello.
I'm interested in your project, and want to contribute, especially to support #41.

I tried have gitmask run on my environment and update the document adding those instructions.
And I added changes to specify alternate resources (e.g. S3 bucket names, github account, and so on)
with environment variables.
This would make it easier for developers to contribute to gitmask.
